### PR TITLE
Fix CEP Issue 1096

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
@@ -174,9 +174,13 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
         @Override
         public void onEvent(Event event, long sequence, boolean endOfBatch) throws Exception {
             DataEndpoint endpoint = getDataEndpoint(true);
-            endpoint.collectAndSend(event);
-            if (endOfBatch) {
-                flushAllDataEndpoints();
+            if (endpoint != null) {
+                endpoint.collectAndSend(event);
+                if (endOfBatch) {
+                    flushAllDataEndpoints();
+                }
+            } else {
+                log.info("Dropping events due to shutdown");
             }
         }
     }
@@ -227,7 +231,7 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
                     index = START_INDEX;
                 }
                 if (index == startIndex) {
-                    if (busyWait) {
+                    if (busyWait && !reconnectionService.isShutdown()) {
                         /**
                          * Have fully iterated the data publisher list,
                          * and busy wait until data publisher
@@ -354,8 +358,8 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
     }
 
     public void shutdown() {
-        eventQueue.shutdown();
         reconnectionService.shutdown();
+        eventQueue.shutdown();
         for (DataEndpoint dataEndpoint : dataEndpoints) {
             dataEndpoint.shutdown();
         }


### PR DESCRIPTION
See the following link for the related Jira issue:

https://wso2.org/jira/browse/CEP-1096

The CEP server failed to shutdown because `getDataEndpoint` function continue to
busy wait for active data end points inside `onEvent` method of the
`EventQueueWorker` (which implements `EventHadler`) class even when a graceful
shutdown is being called.

To let `getDataEndpoint` method know that a shutdown is in progress, during a
shutdown, we first shutdown the reconnection service (before shutting down the
eventQueue which can't complete because of the busy waiting) and check inside
the `getDataEndpoint` method the state of reconnection service and return if it
is shutdown.